### PR TITLE
Make the suffix checks case insensitive

### DIFF
--- a/Sources/PennyDiscord/CoinLogic.swift
+++ b/Sources/PennyDiscord/CoinLogic.swift
@@ -24,7 +24,7 @@ public let validSuffixes = [
 
 extension String {
     var hasCoinSuffix: Bool {
-        for suffix in validSuffixes where hasSuffix(suffix) {
+        for suffix in validSuffixes where self.lowercased().hasSuffix(suffix.lowercased()) {
             return true
         }
         return false


### PR DESCRIPTION
Right now `@LotU Thanks` does not work, but `@LotU thanks` does. Does not seem right :)